### PR TITLE
Fix: Import escape from markupsafe

### DIFF
--- a/fluesterfix/__init__.py
+++ b/fluesterfix/__init__.py
@@ -10,7 +10,8 @@ from shutil import rmtree
 from string import ascii_letters, digits
 from subprocess import run
 
-from flask import Flask, escape, jsonify, make_response, redirect, request, url_for
+from flask import Flask, jsonify, make_response, redirect, request, url_for
+from markupsafe import escape
 from nacl.secret import SecretBox
 from nacl.utils import random
 


### PR DESCRIPTION
Compatibility with Flask 3.0.*
With Flask 3.0.0 some deprecated come was removed ("escape and Markup are no longer re-exported from markupsafe").

See https://flask.palletsprojects.com/en/3.0.x/changes/ and https://github.com/pallets/flask/pull/5223